### PR TITLE
Language variant localisation / spell checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Clone or download this repository and run the following:
 python setup.py install
 ```
 
+The *localise* extra for `sphinxwrapper` requires the Python packages for GNU aspell. You can install the extra using pip: `pip install sphinxwrapper[localise]`.
+
 ## Usage example
 The following is a simple usage example showing how to use the `sphinxwrapper` package to make Pocket Sphinx continuously recognise using the default configuration from the default microphone using `pyaudio`.
 ``` Python

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,9 @@ setup(name='sphinxwrapper',
       author='Dane Finlay',
       author_email='Danesprite@gmail.com',
       packages=['sphinxwrapper'],
-      install_requires=['pyaudio', 'pocketsphinx']
+      install_requires=['pyaudio', 'pocketsphinx'],
+      extras_require={
+            "localise": ["aspell-python-py2;python_version<'3.0'",
+                         "aspell-python-py3;python_version>='3.0'"]
+      },
       )

--- a/sphinxwrapper/__init__.py
+++ b/sphinxwrapper/__init__.py
@@ -1,3 +1,10 @@
 from .pocketsphinx_wrap import PocketSphinx, PocketSphinxError
 from .config import *
 from pocketsphinx import Decoder_default_config as DefaultConfig
+
+try:
+    from .localiser import Localiser
+    from .pocketsphinx_localised import LocalisedPocketSphinx
+except ImportError:
+    Localiser = None
+    LocalisedPocketSphinx = None

--- a/sphinxwrapper/localiser.py
+++ b/sphinxwrapper/localiser.py
@@ -1,0 +1,85 @@
+"""
+Classes using GNU aspell to localise between English variants.
+"""
+
+from aspell import Speller
+
+
+class Localiser(object):
+    """
+    This class uses GNU aspell to localise words to the English spelling for the
+    specified language variant - e.g. en_AU, en_UK, en_US.
+
+    Note that the following lenient assumptions are made about words being
+    localised:
+    - words can be misspelled, but should have the correct number of special
+      characters such as apostrophes, hyphens and spaces.
+    - words should not be misspelled at the start: i.e. 'bcolor' instead of
+      'color'
+    """
+    def __init__(self, lang):
+        """
+        :type lang: str
+        """
+        # Set up an AspellSpeller object
+        self.speller = Speller(("lang", lang))
+
+        # Set of words looked up that were incorrect
+        self._incorrect_words = set()
+
+        # Cache of suggestions for strings
+        self._suggestion_cache = {}
+
+    def localise_word(self, word):
+        """
+        Localise a single word.
+        """
+        # Do further checking if the word is not correct
+        if word in self._incorrect_words or not self.speller.check(word):
+            # Add incorrect words to a set for quick lookup
+            self._incorrect_words.add(word)  # sets are distinct
+
+            # TODO It may be better for this function to change the order of suggestions
+
+            def valid(suggestion):
+                # We won't have words that are this incorrect from Pocket Sphinx,
+                # so don't use use these suggestions.
+                if word[0] != suggestion[0]:
+                    return False
+
+                # Assume that 'word' has the correct number of special characters
+                # E.g. 'col-or' and 'col or' aren't valid suggestions for 'color' to
+                # be localised to a non-US English variant
+                for c in [" ", "'", "-"]:
+                    if word.count(c) != suggestion.count(c):
+                        return False
+
+                return True
+
+            # Used cached suggestions where possible
+            if word in self._suggestion_cache.keys():
+                suggestions = self._suggestion_cache[word]
+
+            # Otherwise get them from the speller, filtered through the
+            # validation function.
+            else:
+                suggestions = list(filter(valid, self.speller.suggest(word)))
+                
+                # Cache the suggestions for next time
+                self._suggestion_cache[word] = suggestions
+
+            if suggestions:
+                word = suggestions[0]
+        return word
+
+    def localise_words(self, words):
+        """
+        Localise a string of multiple words using GNU aspell.
+        :type words: str
+        :rtype: str
+        """
+        # Split the string into a list of words and localise each word
+        words = map(self.localise_word, words.split())
+
+        # Join the words into a string again and return it
+        return " ".join(words)

--- a/sphinxwrapper/pocketsphinx_localised.py
+++ b/sphinxwrapper/pocketsphinx_localised.py
@@ -1,0 +1,61 @@
+"""
+This module contains a `PocketSphinx` subclass that localises input and output words
+between English language variants so that the CMU Sphinx US English models can be
+used easily with non-US English.
+
+One use of this is using the US English language model to output localised English.
+"""
+
+from .pocketsphinx_wrap import PocketSphinx
+from pocketsphinx import Hypothesis, Config
+from .localiser import *
+
+
+class LocalisedPocketSphinx(PocketSphinx):
+    """
+    Pocket Sphinx decoder with custom localising for input and output words.
+
+    `in_lang` is the English variant that words will localised to internally.
+    `out_lang` is the variant that hypothesis strings will be in.
+    """
+    def __init__(self, in_lang, out_lang, cfg=PocketSphinx.default_config()):
+        """
+        in_lang and out_lang should be English language identifiers.
+        :param in_lang: input language identifier - e.g. en_US, en_UK, etc
+        :param out_lang: output language identifier
+        :param cfg: PS config object
+        """
+        # Create localisers for the specified languages
+        self.in_localiser = Localiser(in_lang)
+        self.out_localiser = Localiser(out_lang)
+
+        # TODO Localise any search that is set by the cfg: -kws, -keyphrase, -jsgf
+        super(LocalisedPocketSphinx, self).__init__(cfg)
+
+    def localise_from_config(self, cfg):
+        """
+        Create localised versions of grammar files and other specified search
+        settings in a PS config object and modify file names as necessary.
+        :param cfg: PS config object
+        """
+        assert isinstance(cfg, Config)
+        key = "-keyphrase"
+        if cfg.exists(key):
+            localised = self.in_localiser.localise_words(cfg.get_string(key))
+            cfg.set_string(key, localised)
+
+        key = "-jsgf"
+        if cfg.exists(key):
+            # TODO This requires some parsing of grammar files to localise only the tokens.
+            pass
+
+        # TODO -fsg, -kws
+
+    def hyp(self):
+        result = super(LocalisedPocketSphinx, self).hyp()
+        assert isinstance(result, Hypothesis)
+
+        # If there is one, localise the hypothesis string with `out_localiser`.
+        if result and result.hypstr:
+            result.hypstr = self.out_localiser.localise_words(result.hypstr)
+        return result


### PR DESCRIPTION
This adds a `PocketSphinx` decoder subclass that can localise input and output words between English variants while still using the default US English models. The project board for this is [here](https://github.com/Danesprite/sphinxwrapper/projects/1). Example usage below:
```Python
LocalisedPocketSphinx(in_lang="en_US", out_lang="en_AU")
```
`Hypothesis` objects from the `hyp` and processing methods will be in Australian English, assuming the dictionary is installed.